### PR TITLE
Deduplicated metatables

### DIFF
--- a/src/matrix.c
+++ b/src/matrix.c
@@ -26,21 +26,6 @@ void ir_matrix_init_lua(lua_State *L) {
 	lua_pushcfunction(L, ir_matrix_zero_lua);
 	lua_setfield(L, -2, "zero");
 
-    // mat.meta
-	lua_createtable(L, 0, 3);
-
-	lua_pushcfunction(L, ir_matrix_index_lua);
-	lua_setfield(L, -2, "__index");
-
-	lua_pushcfunction(L, ir_matrix_multiply_lua);
-	lua_setfield(L, -2, "__mul");
-
-    lua_pushcfunction(L, ir_matrix_free_lua);
-    lua_setfield(L, -2, "__gc");
-
-    lua_setfield(L, -2, "meta");
-    // /mat.meta
-
 	lua_setfield(L, -2, "mat");
 }
 
@@ -55,9 +40,11 @@ void ir_matrix_pushmatrix(lua_State *L, mat4 *victim) {
     *userdata = victim;
 
     lua_getglobal(L, "ir");
-    lua_getfield(L, -1, "mat");
+    lua_getfield(L, -1, "internal");
     lua_replace(L, -2);
     lua_getfield(L, -1, "meta");
+    lua_replace(L, -2);
+    lua_getfield(L, -1, "mat");
     lua_replace(L, -2);
 
 	lua_setmetatable(L, -2);

--- a/src/matrix.c
+++ b/src/matrix.c
@@ -6,6 +6,7 @@
 #include <string.h>
 
 #include "matrix.h"
+#include "lua.h"
 #include "model.h"
 
 // NOTE: For potential windows support we'd need _aligned_malloc instead ~FabricatorZayac
@@ -25,6 +26,21 @@ void ir_matrix_init_lua(lua_State *L) {
 	lua_pushcfunction(L, ir_matrix_zero_lua);
 	lua_setfield(L, -2, "zero");
 
+    // mat.meta
+	lua_createtable(L, 0, 3);
+
+	lua_pushcfunction(L, ir_matrix_index_lua);
+	lua_setfield(L, -2, "__index");
+
+	lua_pushcfunction(L, ir_matrix_multiply_lua);
+	lua_setfield(L, -2, "__mul");
+
+    lua_pushcfunction(L, ir_matrix_free_lua);
+    lua_setfield(L, -2, "__gc");
+
+    lua_setfield(L, -2, "meta");
+    // /mat.meta
+
 	lua_setfield(L, -2, "mat");
 }
 
@@ -38,16 +54,11 @@ void ir_matrix_pushmatrix(lua_State *L, mat4 *victim) {
 	mat4 **userdata = lua_newuserdata(L, sizeof(mat4 *));
     *userdata = victim;
 
-	lua_createtable(L, 0, 3);
-
-	lua_pushcfunction(L, ir_matrix_index_lua);
-	lua_setfield(L, -2, "__index");
-
-	lua_pushcfunction(L, ir_matrix_multiply_lua);
-	lua_setfield(L, -2, "__mul");
-
-    lua_pushcfunction(L, ir_matrix_free_lua);
-    lua_setfield(L, -2, "__gc");
+    lua_getglobal(L, "ir");
+    lua_getfield(L, -1, "mat");
+    lua_replace(L, -2);
+    lua_getfield(L, -1, "meta");
+    lua_replace(L, -2);
 
 	lua_setmetatable(L, -2);
 }

--- a/src/model.c
+++ b/src/model.c
@@ -26,7 +26,7 @@ void ir_model_drop(ir_model *model) {
 	lua_close(model->state);
 }
 
-void ir_model_new_internal(ir_model *model);
+void ir_model_new_internal(lua_State *L);
 
 int ir_model_new(ir_model *model) {
 	model->state = luaL_newstate();
@@ -52,19 +52,20 @@ int ir_model_new(ir_model *model) {
 	lua_pushcfunction(model->state, ir_info_lua);
 	lua_setfield(model->state, -2, "info");
 
+	lua_pushcfunction(model->state, ir_shader_new_lua);
+	lua_setfield(model->state, -2, "shader");
+
 	lua_pushcfunction(model->state, ir_model_time_lua);
 	lua_setfield(model->state, -2, "time");
 
 	lua_pushcfunction(model->state, ir_warn_lua);
 	lua_setfield(model->state, -2, "warn");
 
-	ir_model_new_internal(model);
+	ir_model_new_internal(model->state);
 
 	ir_matrix_init_lua(model->state);
 
 	ir_vector_init_lua(model->state);
-
-  ir_shader_init_lua(model->state);
 
 	lua_setglobal(model->state, "ir");
 
@@ -95,155 +96,195 @@ int ir_model_time_lua(lua_State *L) {
 }
 
 // Abandon all hope ye who enter here.
-void ir_model_new_internal(ir_model *model) {
-	lua_createtable(model->state, 0, 47);
+void ir_model_new_internal(lua_State *L) {
+	lua_createtable(L, 0, 48);
 
 	// Internal Functions
 
-	lua_pushcfunction(model->state, ir_view_clear_lua);
-	lua_setfield(model->state, -2, "clear");
+	lua_pushcfunction(L, ir_view_clear_lua);
+	lua_setfield(L, -2, "clear");
 
-	lua_pushcfunction(model->state, ir_subscription_frametimer_lua);
-	lua_setfield(model->state, -2, "frametimer");
+	lua_pushcfunction(L, ir_subscription_frametimer_lua);
+	lua_setfield(L, -2, "frametimer");
 
-	lua_pushcfunction(model->state, ir_resources_fetch_lua);
-	lua_setfield(model->state, -2, "fetch");
+	lua_pushcfunction(L, ir_resources_fetch_lua);
+	lua_setfield(L, -2, "fetch");
 
-	lua_pushcfunction(model->state, ir_view_fullscreen_lua);
-	lua_setfield(model->state, -2, "fullscreen");
+	lua_pushcfunction(L, ir_view_fullscreen_lua);
+	lua_setfield(L, -2, "fullscreen");
 
-	lua_pushcfunction(model->state, ir_view_height_lua);
-	lua_setfield(model->state, -2, "height");
+	lua_pushcfunction(L, ir_view_height_lua);
+	lua_setfield(L, -2, "height");
 
-	lua_pushcfunction(model->state, ir_resources_list_lua);
-	lua_setfield(model->state, -2, "list");
+	lua_pushcfunction(L, ir_resources_list_lua);
+	lua_setfield(L, -2, "list");
 
-	lua_pushcfunction(model->state, ir_resources_mount_lua);
-	lua_setfield(model->state, -2, "mount");
+	lua_pushcfunction(L, ir_resources_mount_lua);
+	lua_setfield(L, -2, "mount");
 
-	lua_pushcfunction(model->state, ir_model_mouselock_lua);
-	lua_setfield(model->state, -2, "mouselock");
+	lua_pushcfunction(L, ir_model_mouselock_lua);
+	lua_setfield(L, -2, "mouselock");
 
-	lua_pushcfunction(model->state, ir_subscription_poll_lua);
-	lua_setfield(model->state, -2, "poll");
+	lua_pushcfunction(L, ir_subscription_poll_lua);
+	lua_setfield(L, -2, "poll");
 
-	lua_pushcfunction(model->state, ir_view_present_lua);
-	lua_setfield(model->state, -2, "present");
+	lua_pushcfunction(L, ir_view_present_lua);
+	lua_setfield(L, -2, "present");
 
-	lua_pushcfunction(model->state, ir_view_render_lua);
-	lua_setfield(model->state, -2, "render");
+	lua_pushcfunction(L, ir_view_render_lua);
+	lua_setfield(L, -2, "render");
 
-	lua_pushcfunction(model->state, ir_view_setcamera_lua);
-	lua_setfield(model->state, -2, "setcamera");
+	lua_pushcfunction(L, ir_view_setcamera_lua);
+	lua_setfield(L, -2, "setcamera");
 
-	lua_pushcfunction(model->state, ir_view_texturemap_lua);
-	lua_setfield(model->state, -2, "texturemap");
+	lua_pushcfunction(L, ir_view_texturemap_lua);
+	lua_setfield(L, -2, "texturemap");
 
-	lua_pushcfunction(model->state, ir_resources_umount_lua);
-	lua_setfield(model->state, -2, "umount");
+	lua_pushcfunction(L, ir_resources_umount_lua);
+	lua_setfield(L, -2, "umount");
 
-	lua_pushcfunction(model->state, ir_view_width_lua);
-	lua_setfield(model->state, -2, "width");
+	lua_pushcfunction(L, ir_view_width_lua);
+	lua_setfield(L, -2, "width");
 
 	// Internal Constants
 
-	lua_pushinteger(model->state, ALLEGRO_EVENT_JOYSTICK_AXIS);
-	lua_setfield(model->state, -2, "EVENT_JOYSTICK_AXIS");
+	lua_pushinteger(L, ALLEGRO_EVENT_JOYSTICK_AXIS);
+	lua_setfield(L, -2, "EVENT_JOYSTICK_AXIS");
 
-	lua_pushinteger(model->state, ALLEGRO_EVENT_JOYSTICK_BUTTON_DOWN);
-	lua_setfield(model->state, -2, "EVENT_JOYSTICK_BUTTON_DOWN");
+	lua_pushinteger(L, ALLEGRO_EVENT_JOYSTICK_BUTTON_DOWN);
+	lua_setfield(L, -2, "EVENT_JOYSTICK_BUTTON_DOWN");
 
-	lua_pushinteger(model->state, ALLEGRO_EVENT_JOYSTICK_BUTTON_UP);
-	lua_setfield(model->state, -2, "EVENT_JOYSTICK_BUTTON_UP");
+	lua_pushinteger(L, ALLEGRO_EVENT_JOYSTICK_BUTTON_UP);
+	lua_setfield(L, -2, "EVENT_JOYSTICK_BUTTON_UP");
 
-	lua_pushinteger(model->state, ALLEGRO_EVENT_JOYSTICK_CONFIGURATION);
-	lua_setfield(model->state, -2, "EVENT_JOYSTICK_CONFIGURATION");
+	lua_pushinteger(L, ALLEGRO_EVENT_JOYSTICK_CONFIGURATION);
+	lua_setfield(L, -2, "EVENT_JOYSTICK_CONFIGURATION");
 
-	lua_pushinteger(model->state, ALLEGRO_EVENT_KEY_DOWN);
-	lua_setfield(model->state, -2, "EVENT_KEY_DOWN");
+	lua_pushinteger(L, ALLEGRO_EVENT_KEY_DOWN);
+	lua_setfield(L, -2, "EVENT_KEY_DOWN");
 
-	lua_pushinteger(model->state, ALLEGRO_EVENT_KEY_CHAR);
-	lua_setfield(model->state, -2, "EVENT_KEY_CHAR");
+	lua_pushinteger(L, ALLEGRO_EVENT_KEY_CHAR);
+	lua_setfield(L, -2, "EVENT_KEY_CHAR");
 
-	lua_pushinteger(model->state, ALLEGRO_EVENT_KEY_UP);
-	lua_setfield(model->state, -2, "EVENT_KEY_UP");
+	lua_pushinteger(L, ALLEGRO_EVENT_KEY_UP);
+	lua_setfield(L, -2, "EVENT_KEY_UP");
 
-	lua_pushinteger(model->state, ALLEGRO_EVENT_MOUSE_AXES);
-	lua_setfield(model->state, -2, "EVENT_MOUSE_AXES");
+	lua_pushinteger(L, ALLEGRO_EVENT_MOUSE_AXES);
+	lua_setfield(L, -2, "EVENT_MOUSE_AXES");
 
-	lua_pushinteger(model->state, ALLEGRO_EVENT_MOUSE_BUTTON_DOWN);
-	lua_setfield(model->state, -2, "EVENT_MOUSE_BUTTON_DOWN");
+	lua_pushinteger(L, ALLEGRO_EVENT_MOUSE_BUTTON_DOWN);
+	lua_setfield(L, -2, "EVENT_MOUSE_BUTTON_DOWN");
 
-	lua_pushinteger(model->state, ALLEGRO_EVENT_MOUSE_BUTTON_UP);
-	lua_setfield(model->state, -2, "EVENT_MOUSE_BUTTON_UP");
+	lua_pushinteger(L, ALLEGRO_EVENT_MOUSE_BUTTON_UP);
+	lua_setfield(L, -2, "EVENT_MOUSE_BUTTON_UP");
 
-	lua_pushinteger(model->state, ALLEGRO_EVENT_MOUSE_ENTER_DISPLAY);
-	lua_setfield(model->state, -2, "EVENT_MOUSE_ENTER_DISPLAY");
+	lua_pushinteger(L, ALLEGRO_EVENT_MOUSE_ENTER_DISPLAY);
+	lua_setfield(L, -2, "EVENT_MOUSE_ENTER_DISPLAY");
 
-	lua_pushinteger(model->state, ALLEGRO_EVENT_MOUSE_LEAVE_DISPLAY);
-	lua_setfield(model->state, -2, "EVENT_MOUSE_LEAVE_DISPLAY");
+	lua_pushinteger(L, ALLEGRO_EVENT_MOUSE_LEAVE_DISPLAY);
+	lua_setfield(L, -2, "EVENT_MOUSE_LEAVE_DISPLAY");
 
-	lua_pushinteger(model->state, ALLEGRO_EVENT_MOUSE_WARPED);
-	lua_setfield(model->state, -2, "EVENT_MOUSE_WARPED");
+	lua_pushinteger(L, ALLEGRO_EVENT_MOUSE_WARPED);
+	lua_setfield(L, -2, "EVENT_MOUSE_WARPED");
 
-	lua_pushinteger(model->state, ALLEGRO_EVENT_TIMER);
-	lua_setfield(model->state, -2, "EVENT_TIMER");
+	lua_pushinteger(L, ALLEGRO_EVENT_TIMER);
+	lua_setfield(L, -2, "EVENT_TIMER");
 
-	lua_pushinteger(model->state, ALLEGRO_EVENT_DISPLAY_EXPOSE);
-	lua_setfield(model->state, -2, "EVENT_DISPLAY_EXPOSE");
+	lua_pushinteger(L, ALLEGRO_EVENT_DISPLAY_EXPOSE);
+	lua_setfield(L, -2, "EVENT_DISPLAY_EXPOSE");
 
-	lua_pushinteger(model->state, ALLEGRO_EVENT_DISPLAY_RESIZE);
-	lua_setfield(model->state, -2, "EVENT_DISPLAY_RESIZE");
+	lua_pushinteger(L, ALLEGRO_EVENT_DISPLAY_RESIZE);
+	lua_setfield(L, -2, "EVENT_DISPLAY_RESIZE");
 
-	lua_pushinteger(model->state, ALLEGRO_EVENT_DISPLAY_CLOSE);
-	lua_setfield(model->state, -2, "EVENT_DISPLAY_CLOSE");
+	lua_pushinteger(L, ALLEGRO_EVENT_DISPLAY_CLOSE);
+	lua_setfield(L, -2, "EVENT_DISPLAY_CLOSE");
 
-	lua_pushinteger(model->state, ALLEGRO_EVENT_DISPLAY_LOST);
-	lua_setfield(model->state, -2, "EVENT_DISPLAY_LOST");
+	lua_pushinteger(L, ALLEGRO_EVENT_DISPLAY_LOST);
+	lua_setfield(L, -2, "EVENT_DISPLAY_LOST");
 
-	lua_pushinteger(model->state, ALLEGRO_EVENT_DISPLAY_FOUND);
-	lua_setfield(model->state, -2, "EVENT_DISPLAY_FOUND");
+	lua_pushinteger(L, ALLEGRO_EVENT_DISPLAY_FOUND);
+	lua_setfield(L, -2, "EVENT_DISPLAY_FOUND");
 
-	lua_pushinteger(model->state, ALLEGRO_EVENT_DISPLAY_SWITCH_IN);
-	lua_setfield(model->state, -2, "EVENT_DISPLAY_SWITCH_IN");
+	lua_pushinteger(L, ALLEGRO_EVENT_DISPLAY_SWITCH_IN);
+	lua_setfield(L, -2, "EVENT_DISPLAY_SWITCH_IN");
 
-	lua_pushinteger(model->state, ALLEGRO_EVENT_DISPLAY_SWITCH_OUT);
-	lua_setfield(model->state, -2, "EVENT_DISPLAY_SWITCH_OUT");
+	lua_pushinteger(L, ALLEGRO_EVENT_DISPLAY_SWITCH_OUT);
+	lua_setfield(L, -2, "EVENT_DISPLAY_SWITCH_OUT");
 
-	lua_pushinteger(model->state, ALLEGRO_EVENT_DISPLAY_ORIENTATION);
-	lua_setfield(model->state, -2, "EVENT_DISPLAY_ORIENTATION");
+	lua_pushinteger(L, ALLEGRO_EVENT_DISPLAY_ORIENTATION);
+	lua_setfield(L, -2, "EVENT_DISPLAY_ORIENTATION");
 
-	lua_pushinteger(model->state, ALLEGRO_EVENT_DISPLAY_HALT_DRAWING);
-	lua_setfield(model->state, -2, "EVENT_DISPLAY_HALT_DRAWING");
+	lua_pushinteger(L, ALLEGRO_EVENT_DISPLAY_HALT_DRAWING);
+	lua_setfield(L, -2, "EVENT_DISPLAY_HALT_DRAWING");
 
-	lua_pushinteger(model->state, ALLEGRO_EVENT_DISPLAY_RESUME_DRAWING);
-	lua_setfield(model->state, -2, "EVENT_DISPLAY_RESUME_DRAWING");
+	lua_pushinteger(L, ALLEGRO_EVENT_DISPLAY_RESUME_DRAWING);
+	lua_setfield(L, -2, "EVENT_DISPLAY_RESUME_DRAWING");
 
-	lua_pushinteger(model->state, ALLEGRO_EVENT_TIMER);
-	lua_setfield(model->state, -2, "EVENT_TIMER");
+	lua_pushinteger(L, ALLEGRO_EVENT_TIMER);
+	lua_setfield(L, -2, "EVENT_TIMER");
 
-	lua_pushinteger(model->state, ALLEGRO_EVENT_TOUCH_BEGIN);
-	lua_setfield(model->state, -2, "EVENT_TOUCH_BEGIN");
+	lua_pushinteger(L, ALLEGRO_EVENT_TOUCH_BEGIN);
+	lua_setfield(L, -2, "EVENT_TOUCH_BEGIN");
 
-	lua_pushinteger(model->state, ALLEGRO_EVENT_TOUCH_END);
-	lua_setfield(model->state, -2, "EVENT_TOUCH_END");
+	lua_pushinteger(L, ALLEGRO_EVENT_TOUCH_END);
+	lua_setfield(L, -2, "EVENT_TOUCH_END");
 
-	lua_pushinteger(model->state, ALLEGRO_EVENT_TOUCH_MOVE);
-	lua_setfield(model->state, -2, "EVENT_TOUCH_MOVE");
+	lua_pushinteger(L, ALLEGRO_EVENT_TOUCH_MOVE);
+	lua_setfield(L, -2, "EVENT_TOUCH_MOVE");
 
-	lua_pushinteger(model->state, ALLEGRO_EVENT_TOUCH_CANCEL);
-	lua_setfield(model->state, -2, "EVENT_TOUCH_CANCEL");
+	lua_pushinteger(L, ALLEGRO_EVENT_TOUCH_CANCEL);
+	lua_setfield(L, -2, "EVENT_TOUCH_CANCEL");
 
-	lua_pushinteger(model->state, ALLEGRO_EVENT_DISPLAY_CONNECTED);
-	lua_setfield(model->state, -2, "EVENT_DISPLAY_CONNECTED");
+	lua_pushinteger(L, ALLEGRO_EVENT_DISPLAY_CONNECTED);
+	lua_setfield(L, -2, "EVENT_DISPLAY_CONNECTED");
 
-	lua_pushinteger(model->state, ALLEGRO_EVENT_DISPLAY_DISCONNECTED);
-	lua_setfield(model->state, -2, "EVENT_DISPLAY_DISCONNECTED");
+	lua_pushinteger(L, ALLEGRO_EVENT_DISPLAY_DISCONNECTED);
+	lua_setfield(L, -2, "EVENT_DISPLAY_DISCONNECTED");
 
-	lua_pushinteger(model->state, ALLEGRO_EVENT_DROP);
-	lua_setfield(model->state, -2, "EVENT_DROP");
+	lua_pushinteger(L, ALLEGRO_EVENT_DROP);
+	lua_setfield(L, -2, "EVENT_DROP");
 
-	lua_setfield(model->state, -2, "internal");
+    // meta
+    lua_createtable(L, 0, 2);
+
+    // shader_meta
+	lua_createtable(L, 0, 1);
+
+	lua_pushcfunction(L, ir_shader_drop_lua);
+	lua_setfield(L, -2, "__gc");
+
+	lua_createtable(L, 0, 1);
+
+	lua_pushstring(L, "shader");
+	lua_setfield(L, -2, "__type");
+
+	lua_pushcfunction(L, ir_shader_use_lua);
+	lua_setfield(L, -2, "use");
+
+	lua_setfield(L, -2, "__index");
+
+    lua_setfield(L, -2, "shader");
+    // /shader_meta
+
+    // mat_meta
+	lua_createtable(L, 0, 3);
+
+	lua_pushcfunction(L, ir_matrix_index_lua);
+	lua_setfield(L, -2, "__index");
+
+	lua_pushcfunction(L, ir_matrix_multiply_lua);
+	lua_setfield(L, -2, "__mul");
+
+    lua_pushcfunction(L, ir_matrix_free_lua);
+    lua_setfield(L, -2, "__gc");
+
+    lua_setfield(L, -2, "mat");
+    // /mat_meta
+
+    lua_setfield(L, -2, "meta");
+    // /meta
+
+	lua_setfield(L, -2, "internal");
 }
 
 int ir_model_mouselock_lua(lua_State *L) {

--- a/src/model.c
+++ b/src/model.c
@@ -11,6 +11,7 @@
 #include "matrix.h"
 #include "model.h"
 #include "resources.h"
+#include "shader.h"
 #include "subscription.h"
 #include "view.h"
 
@@ -51,9 +52,6 @@ int ir_model_new(ir_model *model) {
 	lua_pushcfunction(model->state, ir_info_lua);
 	lua_setfield(model->state, -2, "info");
 
-	lua_pushcfunction(model->state, ir_shader_new_lua);
-	lua_setfield(model->state, -2, "shader");
-
 	lua_pushcfunction(model->state, ir_model_time_lua);
 	lua_setfield(model->state, -2, "time");
 
@@ -65,6 +63,8 @@ int ir_model_new(ir_model *model) {
 	ir_matrix_init_lua(model->state);
 
 	ir_vector_init_lua(model->state);
+
+  ir_shader_init_lua(model->state);
 
 	lua_setglobal(model->state, "ir");
 

--- a/src/shader.c
+++ b/src/shader.c
@@ -17,30 +17,6 @@ void ir_shader_drop(ir_shader *shader) {
 	glDeleteShader(shader->vertex);
 }
 
-void ir_shader_init_lua(lua_State *L) {
-	lua_pushcfunction(L, ir_shader_new_lua);
-	lua_setfield(L, -2, "shader");
-
-    // shader_meta
-	lua_createtable(L, 0, 1);
-
-	lua_pushcfunction(L, ir_shader_drop_lua);
-	lua_setfield(L, -2, "__gc");
-
-	lua_createtable(L, 0, 1);
-
-	lua_pushstring(L, "shader");
-	lua_setfield(L, -2, "__type");
-
-	lua_pushcfunction(L, ir_shader_use_lua);
-	lua_setfield(L, -2, "use");
-
-	lua_setfield(L, -2, "__index");
-
-    lua_setfield(L, -2, "shader_meta");
-    // /shader_meta
-}
-
 int ir_shader_new(
 	ir_shader *shader,
 	size_t vert_len,
@@ -170,7 +146,11 @@ int ir_shader_new_lua(lua_State *L) {
 	}
 
     lua_getglobal(L, "ir");
-    lua_getfield(L, -1,  "shader_meta");
+    lua_getfield(L, -1,  "internal");
+    lua_replace(L, -2);
+    lua_getfield(L, -1,  "meta");
+    lua_replace(L, -2);
+    lua_getfield(L, -1,  "shader");
     lua_replace(L, -2);
 
 	lua_setmetatable(L, -2);

--- a/src/shader.h
+++ b/src/shader.h
@@ -9,6 +9,7 @@
 
 #include <allegro5/allegro_opengl.h>
 #include <GL/glext.h>
+#include <luajit-2.1/lua.h>
 
 typedef struct {
 	GLuint fragment;
@@ -29,6 +30,7 @@ void ir_shader_use(ir_shader *shader);
 
 // Lua interface
 
+void ir_shader_init_lua(lua_State *L);
 int ir_shader_isshader(lua_State *L, int index);
 
 int ir_shader_drop_lua(lua_State *L);

--- a/src/shader.h
+++ b/src/shader.h
@@ -30,7 +30,6 @@ void ir_shader_use(ir_shader *shader);
 
 // Lua interface
 
-void ir_shader_init_lua(lua_State *L);
 int ir_shader_isshader(lua_State *L, int index);
 
 int ir_shader_drop_lua(lua_State *L);


### PR DESCRIPTION
Made it so metatables for shaders and matrices are created during initialization and referenced each time a matrix/shader object are created instead of creating a new metatable for each new object